### PR TITLE
「すべて」folderへAjaxで遷移するとその後のfolderの保存ができなくなるバグの修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,12 +95,16 @@ switch (pageMataData.siteId) {
     } else if (pageMataData.contentKind === 'folder') {
       // NOTE: folder のパンくずリストの枠である .folder-breadcrumb の中には、各パンくずである .folder-breadcrumb-item-wrapper だけが入っている。
       //       folder の表記は full path 的であるため、変更されれば必ず要素が変化する。
-      const folderPageObserverTarget = document.querySelector('[data-hypernova-key="FolderContainer"] .folder-breadcrumb')
+      const folderPageObserverTarget = document.querySelector('[data-hypernova-key="FolderContainer"]')
       if (folderPageObserverTarget) {
         const mo = new MutationObserver((mutations, observer) => {
           // TODO: ここより後に URL が変更されるので、一拍置いてから保存している。ただ雑なので、DOM から抽出するように変更する方がより良い。
           setTimeout(() => {
-            updateFootprintOfKibelaFolder(storage, location.origin, location.pathname)
+            // NOTE: 本アプリでは folder から除外している「すべて」folder へも Ajax で遷移できるので、それを除外している。
+            const currentPageMataData = classifyPage(location.href)
+            if (currentPageMataData.siteId === 'kibela' && currentPageMataData.contentKind === 'folder') {
+              updateFootprintOfKibelaFolder(storage, location.origin, location.pathname)
+            }
           }, 500)
         })
         mo.observe(folderPageObserverTarget, {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -59,6 +59,10 @@ describe('classifyPage', () => {
       expected: {siteId: 'kibela', contentKind: 'folder', teamId: 'foo'},
     },
     {
+      url: 'https://foo.kibe.la/notes/folder?order_by=title&group_id=1',
+      expected: {siteId: 'kibela', contentKind: 'unknown', teamId: 'foo'},
+    },
+    {
       url: 'https://foo.kibe.la/notes/123/edit',
       expected: {siteId: 'kibela', contentKind: 'unknown', teamId: 'foo'},
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,9 @@ export const classifyPage = (url: string): PageMetaData => {
       teamId: host.replace(/\.kibe\.la$/, ''),
       contentKind: /^\/notes\/\d+$/.test(pathname)
         ? 'note'
+        // NOTE: 「すべて」と表示される "/notes/folder" は除外する。
+        //       folder を表示する DOM 要素がなくなるので、非同期で保存する処理が難しくなるため。
+        //       また、構造上は他の folder のトップになるはずだが、それが基本的には folder の表記に含まれていないので、混乱させそう。
         : pathname.startsWith('/notes/folder/')
           ? 'folder'
           : 'unknown'


### PR DESCRIPTION
「すべて」folder への Ajax の遷移は、ページ上部のパンくずリストからと、左ナビのグループ選択プルダウンから行われる。