### PR TITLE
Kibelaのfolderはgroup_idがあればそれもurlへ含めて保存する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ if (pageMataData.siteId === 'esa') {
           //       また、既存 UI に遷移元がたくさんあるので、困らないはず。
           const currentPageMataData = classifyPage(location.href)
           if (currentPageMataData.siteId === 'kibela' && currentPageMataData.contentKind === 'folderOthers') {
-            updateFootprintOfKibelaFolder(storage, location.origin, location.pathname)
+            updateFootprintOfKibelaFolder(storage, location.href)
           }
         }, 500)
       })
@@ -117,7 +117,7 @@ if (pageMataData.siteId === 'esa') {
       })
     }
     if (pageMataData.contentKind === 'folderOthers') {
-      updateFootprintOfKibelaFolder(storage, location.origin, location.pathname)
+      updateFootprintOfKibelaFolder(storage, location.href)
     }
   }
 }

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -61,8 +61,7 @@ describe('updateFootprintOfKibelaFolder', () => {
 
   const table: {
     args: {
-      origin: UpdateFootprintOfKibelaFolderParameters[1];
-      pathname: UpdateFootprintOfKibelaFolderParameters[2];
+      url: UpdateFootprintOfKibelaFolderParameters[1];
     },
     name: string,
     expected: Footprint[],
@@ -70,17 +69,26 @@ describe('updateFootprintOfKibelaFolder', () => {
     {
       name: 'it works',
       args: {
-        origin: 'https://nowhere.kibe.la',
-        pathname: '/notes/folder/foo/%E3%81%B0%E3%83%BC',
+        url: 'https://nowhere.kibe.la/notes/folder/foo/%E3%81%B0%E3%83%BC',
       },
       expected: [{
         title: 'foo/ばー',
         url: 'https://nowhere.kibe.la/notes/folder/foo/%E3%81%B0%E3%83%BC',
       }],
     },
+    {
+      name: 'it appends "group_id" param to url when the passed url includes it',
+      args: {
+        url: 'https://nowhere.kibe.la/notes/folder/foo?group_id=2&order_by=title',
+      },
+      expected: [{
+        title: 'foo',
+        url: 'https://nowhere.kibe.la/notes/folder/foo?group_id=2',
+      }],
+    },
   ]
   test.each(table)('$name', async ({args, expected}) => {
-    await updateFootprintOfKibelaFolder(storage, args.origin, args.pathname)
+    await updateFootprintOfKibelaFolder(storage, args.url)
     expect(storage.saveFootprints).toHaveBeenCalledTimes(1)
     expect(storage.saveFootprints).toHaveBeenCalledWith(expected)
   })

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -51,11 +51,14 @@ export const updateFootprintOfEsaCategory = (storage: Storage, origin: string, h
   return updateFootprint(storage, newFootprint)
 }
 
-export const updateFootprintOfKibelaFolder = (storage: Storage, origin: string, pathname: string): Promise<void> => {
-  const folder = decodeURIComponent(pathname.replace(/^\/notes\/folder\//, ''))
+export const updateFootprintOfKibelaFolder = (storage: Storage, url: string): Promise<void> => {
+  const urlObj = new URL(url)
+  const folder = decodeURIComponent(urlObj.pathname.replace(/^\/notes\/folder\//, ''))
+  const groupId = urlObj.searchParams.get('group_id')
+  const queryString = groupId ? `?group_id=${encodeURIComponent(groupId)}` : ''
   const newFootprint: Footprint = {
     title: folder,
-    url: origin + pathname,
+    url: urlObj.origin + urlObj.pathname + queryString,
   }
   return updateFootprint(storage, newFootprint)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,14 @@ export type PageMetaData = {
 }
 
 export type Footprint = {
+  /**
+   * 画面のタイトル。Searcher の選択肢の表示名になる。
+   * Kibela の folder のときは、グループを横断した重複は可能なので一意にならない。
+   */
   title: string;
+  /**
+   * 画面の URL。一意。
+   */
   url: string;
 }
 


### PR DESCRIPTION
## 背景

Kibela は folder ツリーがグループ毎にそれぞれ定義されている。
その関係を `group_id` という GET Parameter で表現している。

つまり、group_id を含めて folder の URL は一意になる。