### PR TITLE
最大保存件数を10000へ増やす

### DIFF
--- a/src/reducers.test.ts
+++ b/src/reducers.test.ts
@@ -51,15 +51,15 @@ describe('updateFootprint', () => {
   test.each(table)('$name', ({footprints, newFootprint, expected}) => {
     expect(updateFootprint(newFootprint)(footprints)).toStrictEqual(expected)
   })
-  test('it returns up to 1000', () => {
-    const footprints1000: Footprint[] = []
-    for (let i = 0; i < 1000; i++) {
-      footprints1000.push({
+  test('it returns up to 10000', () => {
+    const footprints10001: Footprint[] = []
+    for (let i = 0; i < 10001; i++) {
+      footprints10001.push({
         title: '',
         url: `https://example.com/${i}`,
       })
     }
-    expect(footprints1000).toHaveLength(1000)
-    expect(updateFootprint({title: '', url: 'https://not-example.com'})(footprints1000)).toHaveLength(1000)
+    expect(footprints10001).toHaveLength(10001)
+    expect(updateFootprint({title: '', url: 'https://not-example.com'})(footprints10001)).toHaveLength(10000)
   })
 })

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -2,7 +2,7 @@ import {
   Footprint,
 } from './utils'
 
-const maxFootprints = 1000 as const
+const maxFootprints = 10000 as const
 
 /**
  * Footprintを追加または更新する。識別子はURL。

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -9,7 +9,9 @@ import {
 export type Storage = {
   footprintsKey: string;
   loadFootprints: () => Promise<Footprint[]>;
-  // TODO: 保存する件数に上限を設ける。
+  /**
+   * @param footprints 件数の上限は考慮しない。呼び出し元で調整する。
+   */
   saveFootprints: (footprints: Footprint[]) => Promise<void>;
 }
 


### PR DESCRIPTION
## 背景

1000 件だと最大数が気になることもありそうなので、永遠に気にならなそうな件数まであげる。

## 😩  `chrome.storage.sync` の 1 key には 8192 bytes しか保存できなかった

https://developer.chrome.com/docs/extensions/reference/storage/#properties

> QUOTA_BYTES
102400
The maximum total amount (in bytes) of data that can be stored in sync storage, as measured by the JSON stringification of every value plus every key's length. Updates that would cause this limit to be exceeded fail immediately and set runtime.lastError.

> QUOTA_BYTES_PER_ITEM
8192
The maximum size (in bytes) of each individual item in sync storage, as measured by the JSON stringification of its value plus its key length. Updates containing items larger than this limit will fail immediately and set runtime.lastError.

だいたい 1 footprint が 50-200 bytes くらい。

そうなると 200 byptes として、全サイトを通して数十個しか保存できない。
つまり、設計が破綻している。

----

一方で、おそらくは `localStorage` 準拠の `chrome.storage.local` は、合計 5 mb の制約のみ。
per key/value の制約はなさそう。

> QUOTA_BYTES
5242880
The maximum amount (in bytes) of data that can be stored in local storage, as measured by the JSON stringification of every value plus every key’s length. This value will be ignored if the extension has the unlimitedStorage permission. Updates that would cause this limit to be exceeded fail immediately and set runtime.lastError.

こっちならまだ現実的。