### PR TITLE
最大容量が少なかったのでchrome.storage.localへ変更する

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -9,7 +9,9 @@ import {
 export type Storage = {
   footprintsKey: string;
   loadFootprints: () => Promise<Footprint[]>;
-  // TODO: 保存する件数に上限を設ける。
+  /**
+   * @param footprints 件数の上限は考慮しない。呼び出し元で調整する。
+   */
   saveFootprints: (footprints: Footprint[]) => Promise<void>;
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -28,6 +28,7 @@ export const createChromeStorage = (siteId: PageMetaData['siteId'], teamId: stri
       })
     },
     saveFootprints: (footprints: Footprint[]) => {
+      // TODO: chrome.storage.local の最大容量（5mb）を超えたときのことを考慮する。 
       const serializedFootprints = JSON.stringify(footprints)
       return new Promise(resolve => {
         chrome.storage.local.set({[footprintsKey]: serializedFootprints}, () => {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -21,7 +21,7 @@ export const createChromeStorage = (siteId: PageMetaData['siteId'], teamId: stri
     footprintsKey,
     loadFootprints: () => {
       return new Promise(resolve => {
-        chrome.storage.sync.get([footprintsKey], (result) => {
+        chrome.storage.local.get([footprintsKey], (result) => {
           const rawFootprints = result[footprintsKey]
           resolve(rawFootprints ? JSON.parse(rawFootprints) : [])
         })
@@ -30,7 +30,7 @@ export const createChromeStorage = (siteId: PageMetaData['siteId'], teamId: stri
     saveFootprints: (footprints: Footprint[]) => {
       const serializedFootprints = JSON.stringify(footprints)
       return new Promise(resolve => {
-        chrome.storage.sync.set({[footprintsKey]: serializedFootprints}, () => {
+        chrome.storage.local.set({[footprintsKey]: serializedFootprints}, () => {
           resolve()
         })
       })


### PR DESCRIPTION
## 問題

`chrome.storage.sync` の per key/value の最大容量が 8kb だったので、設計が破綻していた。Ref) #35 

`chrome.storage.local` へ変更し、その合計 5mb 以下という制約で見直す。

## 試算

`{title, url}` の byte 数は 50bytes - 200bytes の範囲だった。

大きめの 200 bytes だとして、総容量 5mb だと、以下のようなレコード数が保存できる。
```
5 * 1024 * 1024 / 200
26214.4
```

まぁ、サイト別に 1000 件なら大丈夫そう。